### PR TITLE
refactor(routes): update protected route names

### DIFF
--- a/packages/react/src/routes/getSaasAdminRoutes.tsx
+++ b/packages/react/src/routes/getSaasAdminRoutes.tsx
@@ -1,21 +1,19 @@
 import { Route } from "react-router-dom";
 
 import { DEFAULT_PATHS } from "@/constants";
-import { AdminProtectedRoutesProperties } from "@/types/routes";
+import { AdminRoutesProperties } from "@/types/routes";
 import {
   AccountAddPage,
   AccountEditPage,
   AccountViewPage,
 } from "@/views/Account";
 
-export const getSaasAdminProtectedRoutes = (
-  options?: AdminProtectedRoutesProperties,
-) => {
+export const getSaasAdminRoutes = (options?: AdminRoutesProperties) => {
   const { accountsAdd, accountsEdit, accountsView } = options?.routes || {};
 
   // TODO save path overwrites in config so that other components can use it.
 
-  const protectedRoutes = [
+  const routes = [
     {
       path: accountsAdd?.path || DEFAULT_PATHS.ACCOUNTS_ADD,
       element: accountsAdd?.element || <AccountAddPage />,
@@ -35,7 +33,7 @@ export const getSaasAdminProtectedRoutes = (
 
   return (
     <>
-      {protectedRoutes.map((route) =>
+      {routes.map((route) =>
         !route.disabled ? (
           <Route key={route.path} path={route.path} element={route.element} />
         ) : null,

--- a/packages/react/src/routes/getSaasAppPublicRoutes.tsx
+++ b/packages/react/src/routes/getSaasAppPublicRoutes.tsx
@@ -9,7 +9,7 @@ export const getSaasAppPublicRoutes = (options?: AppPublicRoutesProperties) => {
 
   // TODO save path overwrites in config so that other components can use it.
 
-  const publicRoutes = [
+  const routes = [
     {
       path: acceptInvitation?.path || DEFAULT_PATHS.ACCEPT_INVITATION,
       element: acceptInvitation?.element || <AcceptInvitationPage />,
@@ -24,7 +24,7 @@ export const getSaasAppPublicRoutes = (options?: AppPublicRoutesProperties) => {
 
   return (
     <>
-      {publicRoutes.map((route) =>
+      {routes.map((route) =>
         !route.disabled ? (
           <Route key={route.path} path={route.path} element={route.element} />
         ) : null,

--- a/packages/react/src/routes/getSaasAppRoutes.tsx
+++ b/packages/react/src/routes/getSaasAppRoutes.tsx
@@ -1,17 +1,15 @@
 import { Route } from "react-router-dom";
 
 import { DEFAULT_PATHS } from "@/constants";
-import { AppProtectedRoutesProperties } from "@/types/routes";
+import { AppRoutesProperties } from "@/types/routes";
 import { MyAccountsPage } from "@/views";
 
-export const getSaasAppProtectedRoutes = (
-  options?: AppProtectedRoutesProperties,
-) => {
+export const getSaasAppRoutes = (options?: AppRoutesProperties) => {
   const { myAccounts } = options?.routes || {};
 
   // TODO save path overwrites in config so that other components can use it.
 
-  const protectedRoutes = [
+  const routes = [
     {
       path: myAccounts?.path || DEFAULT_PATHS.MY_ACCOUNTS,
       element: myAccounts?.element || <MyAccountsPage />,
@@ -21,7 +19,7 @@ export const getSaasAppProtectedRoutes = (
 
   return (
     <>
-      {protectedRoutes.map((route) =>
+      {routes.map((route) =>
         !route.disabled ? (
           <Route key={route.path} path={route.path} element={route.element} />
         ) : null,

--- a/packages/react/src/routes/index.ts
+++ b/packages/react/src/routes/index.ts
@@ -1,3 +1,3 @@
-export * from "./getSaasAdminProtectedRoutes";
-export * from "./getSaasAppProtectedRoutes";
+export * from "./getSaasAdminRoutes";
 export * from "./getSaasAppPublicRoutes";
+export * from "./getSaasAppRoutes";

--- a/packages/react/src/types/routes.ts
+++ b/packages/react/src/types/routes.ts
@@ -6,14 +6,14 @@ export type RouteOverwrite = {
   path?: string;
 };
 
-export type AdminProtectedRouteOverwrites = {
+export type AdminRouteOverwrites = {
   accountsAdd?: RouteOverwrite;
   accountsEdit?: RouteOverwrite;
   accountsView?: RouteOverwrite;
   // accounts?: RouteOverwrite; // TODO
 };
 
-export type AppProtectedRouteOverwrites = {
+export type AppRouteOverwrites = {
   // joinAccount?: RouteOverwrite; // TODO
   // myAccount?: RouteOverwrite; // TODO
   myAccounts?: RouteOverwrite;
@@ -23,12 +23,12 @@ export type AppPublicRouteOverwrites = {
   signup?: RouteOverwrite;
 };
 
-export type AdminProtectedRoutesProperties = {
-  routes?: AdminProtectedRouteOverwrites;
+export type AdminRoutesProperties = {
+  routes?: AdminRouteOverwrites;
 };
 
-export type AppProtectedRoutesProperties = {
-  routes?: AppProtectedRouteOverwrites;
+export type AppRoutesProperties = {
+  routes?: AppRouteOverwrites;
 };
 export type AppPublicRoutesProperties = {
   routes?: AppPublicRouteOverwrites;


### PR DESCRIPTION
BREAKING CHANGE:
getSaasAdminProtectedRoutes and getSaasAppProtectedRoutes have been renamed to getSaasAdminRoutes and getSaasAppRoutes, respectively.