### PR TITLE
fix(fastify/migrations): increase accounts table database column to VARCHAR(24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Bug Fixes
+
+* **fastify/migrations:** increase accounts table database column from VARCHAR(10) to VARCHAR(24)
+
 # [0.28.0](https://github.com/prefabs-tech/saas/compare/v0.27.2...v0.28.0) (2025-12-23)
 
 

--- a/packages/fastify/src/migrations/queries.ts
+++ b/packages/fastify/src/migrations/queries.ts
@@ -56,7 +56,7 @@ const createAccountsTableQuery = (
       individual BOOLEAN NOT NULL DEFAULT FALSE,
       type_id INTEGER,
       slug VARCHAR(24),
-      database VARCHAR(10),
+      database VARCHAR(24),
       domain VARCHAR(255),
       UNIQUE (slug),
       UNIQUE (database),


### PR DESCRIPTION
## fix(fastify/migrations): increase accounts table database column to VARCHAR(24)

### Tasks completed

* Increased `database` column length from `VARCHAR(10)` to `VARCHAR(24)` in `createAccountsTableQuery` in `packages/fastify/src/migrations/queries.ts` to support longer database identifiers.
* Updated `CHANGELOG.md` with an Unreleased entry documenting the migration fix under Bug Fixes.