### PR TITLE
chore(ci/deps): update workflow runtime and workspace package versions

### DIFF
--- a/.github/workflows/shipjs-manual-prepare.yml
+++ b/.github/workflows/shipjs-manual-prepare.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
-      - name: Setup node 20
+      - name: Setup node 24
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
       - run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/shipjs-trigger.yml
+++ b/.github/workflows/shipjs-trigger.yml
@@ -4,7 +4,7 @@ on:
     types:
       - closed
 jobs:
-  build:
+  release:
     name: Release
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'releases/v')
@@ -14,11 +14,12 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
-      - name: Setup node 20
+      - name: Setup node 24
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
       - name: Setup pnpm and install dependencies
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [20, 22, 24]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Update CI and release workflow configuration to use newer Node.js versions and align release trigger behavior.
- Bump root development tooling versions (`commitlint`, `typescript`, `turbo`, `shipjs`, and related tooling) to keep the monorepo toolchain current.
- Refresh dependency versions across `packages/fastify`, `packages/react`, and `packages/vue` (including `zod`, `vite`, `typescript`, `@types/node`, `graphql`, `pg`, and related ecosystem packages) for consistency and maintenance updates.

## Test plan
- [ ] Run `pnpm install` to refresh lockfile and ensure dependency resolution is clean.
- [ ] Run `pnpm test` (or workspace-equivalent CI test commands) to validate package compatibility.
- [ ] Run `pnpm lint` and `pnpm typecheck` to verify static checks after upgrades.